### PR TITLE
Fix code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/http-server.js
+++ b/http-server.js
@@ -3,6 +3,9 @@ import http from "http";
 import path from "path";
 import url from "url";
 
+// Define the root directory for serving files
+const ROOT = path.resolve(__dirname, 'public');
+
 // Local port for http server to listen on
 const PORT = 9000;
 
@@ -33,9 +36,13 @@ http
     // Extract URL path
     // Avoid https://en.wikipedia.org/wiki/Directory_traversal_attack
     let sanitizedPath = path
-      .normalize(parsedUrl.pathname)
-      .replace(/^(\.\.[\/\\])+/, "")
-      .substring(1);
+      .normalize(parsedUrl.pathname);
+    const resolvedPath = path.resolve(ROOT, sanitizedPath);
+    if (!resolvedPath.startsWith(ROOT)) {
+      res.statusCode = 403;
+      res.end("Access denied");
+      return;
+    }
 
     if (sanitizedPath === "API_KEY") {
       res.end(API_KEY);


### PR DESCRIPTION
Fixes [https://github.com/daichianoop/Gemini-API-bot-and-OCR/security/code-scanning/3](https://github.com/daichianoop/Gemini-API-bot-and-OCR/security/code-scanning/3)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root directory. This can be achieved by normalizing the path using `path.resolve` and then verifying that the normalized path starts with the root directory. This approach ensures that any directory traversal attempts are neutralized.

1. Define a root directory constant.
2. Use `path.resolve` to normalize the path and remove any `..` segments.
3. Check that the normalized path starts with the root directory.
4. If the check fails, return a 403 status code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
